### PR TITLE
Configure pre-built docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.9.5-buster
 
 LABEL maintainer="Juan Manuel Ruiz Fernández"
 LABEL name="Docker image for AWS CodeBuild GitHub action"
-LABEL version="v1.0.0"
+LABEL version="v1.1.0"
 
 RUN mkdir /opt/action
 

--- a/action.yml
+++ b/action.yml
@@ -32,4 +32,4 @@ inputs:
 
 runs:
   using: "docker"
-  image: "Dockerfile"
+  image: public.ecr.aws/neovasili/aws-codebuild:1.1.0


### PR DESCRIPTION
This PR changes action to avoid build docker image on each execution, instead it will pull a pre-built version of it.